### PR TITLE
Bridge getRouterVersion & Monitor compatibility mode

### DIFF
--- a/src/bridge.h
+++ b/src/bridge.h
@@ -16,6 +16,8 @@
 
 #define RESET_METHOD "$/reset"
 #define BIND_METHOD "$/register"
+#define GET_VERSION_METHOD "$/version"
+
 //#define BRIDGE_ERROR "$/bridgeLog"
 
 #define UPDATE_THREAD_STACK_SIZE    500
@@ -157,6 +159,8 @@ class BridgeClass {
 
     bool started = false;
 
+    MsgPack::str_t router_ver;
+
 public:
 
     explicit BridgeClass(HardwareSerial& serial) {
@@ -201,6 +205,10 @@ public:
         started = call(RESET_METHOD).result(res) && res;
         k_mutex_unlock(&bridge_mutex);
         return res;
+    }
+
+    bool getRouterVersion(MsgPack::str_t& version) {
+        return call(GET_VERSION_METHOD).result(version);
     }
 
     template<typename F>

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -31,6 +31,7 @@ class BridgeMonitor: public Stream {
     RingBufferN<BufferSize> temp_buffer;
     struct k_mutex monitor_mutex{};
     bool _connected = false;
+    bool _compatibility_mode;
 
 public:
     explicit BridgeMonitor(BridgeClass& bridge): bridge(&bridge) {}
@@ -52,6 +53,8 @@ public:
         k_mutex_lock(&monitor_mutex, K_FOREVER);
         bool out = false;
         _connected = bridge->call(MON_CONNECTED_METHOD).result(out) && out;
+        MsgPack::str_t ver;
+        _compatibility_mode = !bridge->call(GET_VERSION_METHOD).result(ver);
         k_mutex_unlock(&monitor_mutex);
         return out;
     }
@@ -114,10 +117,15 @@ public:
             send_buffer += static_cast<char>(buffer[i]);
         }
 
-        size_t written;
-        const bool ret = bridge->call(MON_WRITE_METHOD, send_buffer).result(written);
+        size_t written = 0;
 
-        return ret? written : 0;
+        if (_compatibility_mode) {
+            bridge->call(MON_WRITE_METHOD, send_buffer).result(written);
+        } else {
+            bridge->notify(MON_WRITE_METHOD, send_buffer);
+        }
+
+        return written;
     }
 
     bool reset() {


### PR DESCRIPTION
This PR introduces the features:

- Bridge getRouterVersion method to get the current version of the router if `$/version` is provided
- Monitor compatibility mode uses Bridge->call to write if router is older version