### PR TITLE
feat: Bridge.begin waits to be greenlighted by MPU up to timeout

### DIFF
--- a/src/bridge.h
+++ b/src/bridge.h
@@ -40,7 +40,7 @@ k_sem cleared_sem;
 
 inline void greenLight() {
     Serial.println("Green Light");
-    //k_sem_give(&cleared_sem);
+    k_sem_give(&cleared_sem);
 }
 
 template<typename... Args>


### PR DESCRIPTION
This PR is open to discussion and is an alternative proposal to #32

- It ensures Bridge operations (calls / provide user defined methods) only after Router is **really UP**, signaling via the "greenLight" method
- Waits for a semaphore up to a given timeout so it is backwards compatible