### PR TITLE
misc: warning cleanup

### DIFF
--- a/examples/test_rpc_thread/test_rpc_thread.ino
+++ b/examples/test_rpc_thread/test_rpc_thread.ino
@@ -7,6 +7,8 @@
 
 
 void rpc_thread_entry(void *p1, void *p2, void *p3) {
+    (void)p3; // unused argument
+
     RpcCall<MsgPack::str_t> *call  = reinterpret_cast<RpcCall<MsgPack::str_t>*>(p1);
     struct k_mutex *mtx = reinterpret_cast<struct k_mutex*>(p2);
 

--- a/extras/test/udp_echo/udp_echo.ino
+++ b/extras/test/udp_echo/udp_echo.ino
@@ -14,7 +14,7 @@
  */
 
 #include <Arduino.h>
-#include "src/Arduino_RouterBridge.h"
+#include "Arduino_RouterBridge.h"
 
 // Configuration
 #define LOCAL_UDP_PORT 8888           // Local port to listen on

--- a/extras/test/udp_test/udp_test.ino
+++ b/extras/test/udp_test/udp_test.ino
@@ -6,7 +6,7 @@
  */
 
 #include <Arduino.h>
-#include "src/Arduino_RouterBridge.h"
+#include "Arduino_RouterBridge.h"
 
 // Test configuration
 #define TEST_UDP_PORT 8888

--- a/src/udp_bridge.h
+++ b/src/udp_bridge.h
@@ -96,6 +96,8 @@ public:
     }
 
     uint8_t beginMulticast(IPAddress ip, uint16_t port) override {
+        (void)ip; // unused argument
+
         if (!init()) {
             return 0;
         }
@@ -246,7 +248,7 @@ public:
     // reading stops when the UDP package has been read completely (_remaining = 0)
     int read(unsigned char *buffer, size_t len) override {
         k_mutex_lock(&udp_mutex, K_FOREVER);
-        int i = 0;
+       	size_t i = 0;
         while (_remaining && i < len) {
             if (!temp_buffer.available() && !available()) {
                 k_msleep(1);
@@ -256,12 +258,12 @@ public:
             _remaining--;
         }
         k_mutex_unlock(&udp_mutex);
-        return i;
+        return (int)i;
     }
 
     int read(char *buffer, size_t len) override {
         k_mutex_lock(&udp_mutex, K_FOREVER);
-        int i = 0;
+        size_t i = 0;
         while (_remaining && i < len) {
             if (!temp_buffer.available() && !available()) {
                 k_msleep(1);
@@ -271,7 +273,7 @@ public:
             _remaining--;
         }
         k_mutex_unlock(&udp_mutex);
-        return i;
+        return (int)i;
     }
 
     int peek() override {


### PR DESCRIPTION
Remove additional warnings about unused parameters and signed/unsigned mismatches detected by CI runs.