### PR TITLE
while (Monitor.read() != -1) {} hangs

### DIFF
--- a/src/monitor.h
+++ b/src/monitor.h
@@ -79,8 +79,10 @@ public:
 
     int read() override {
         uint8_t c = 0;
-        read(&c, 1);
-        return c;
+        int cch_read;
+
+        cch_read = read(&c, 1);
+        return cch_read? c : -1;
     }
 
     int read(uint8_t* buffer, size_t size) {


### PR DESCRIPTION
As I mentioned in the ArduinoCore-zephyr issues:
https://github.com/arduino/ArduinoCore-zephyr/issues/320

A sketch that does that will hang as Monitor.read()  when the queue is empty returns 0 not -1, as specified in the Stream class

https://docs.arduino.cc/language-reference/en/functions/communication/stream/streamRead/