### PR TITLE
fix: we need to flush previous run only with hardware serial

### DIFF
--- a/src/bridge.h
+++ b/src/bridge.h
@@ -192,8 +192,10 @@ public:
         while (!*serial_ptr){
             k_yield();
         }
-        // This allows Router to flush broken RPCs from the previous run
+#if defined(ARDUINO_UNO_Q) 
+        // Flush broken RPCs from the previous run on hardware serial.
         serial_ptr->write("MCU starting RPC Bridge communication");
+#endif
         transport = new SerialTransport(*serial_ptr);
 
         client = new RPCClient(*transport);


### PR DESCRIPTION
The USB serial will be closed if the sketch is reset, so we don't need to flush old, broken messages.