### PR TITLE
licence: spdx updates to files changed since 0.4.0

### DIFF
--- a/examples/client/client.ino
+++ b/examples/client/client.ino
@@ -1,3 +1,14 @@
+/*
+    This file is part of the Arduino_RouterBridge library.
+
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
 #include <Arduino_RouterBridge.h>
 
 BridgeTCPClient<> client(Bridge);

--- a/examples/monitor/monitor.ino
+++ b/examples/monitor/monitor.ino
@@ -1,12 +1,12 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) 2025 Arduino SA
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
-    
+
 */
 
 #include <Arduino_RouterBridge.h>

--- a/examples/server/python/main.py
+++ b/examples/server/python/main.py
@@ -1,3 +1,6 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
 # A python sketch that uses RPC Bridge to test the server.ino
 
 import time

--- a/examples/server/server.ino
+++ b/examples/server/server.ino
@@ -1,3 +1,14 @@
+/*
+    This file is part of the Arduino_RouterBridge library.
+
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
 #include <Arduino_RouterBridge.h>
 
 IPAddress localhost(127, 0, 0, 1);

--- a/examples/udp_ntp_client/udp_ntp_client.ino
+++ b/examples/udp_ntp_client/udp_ntp_client.ino
@@ -1,4 +1,15 @@
 /*
+    This file is part of the Arduino_RouterBridge library.
+
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
+/*
   Udp NTP Client
 
   Get the time from a Network Time Protocol (NTP) time server

--- a/extras/test/callbacks_test/callbacks_test.ino
+++ b/extras/test/callbacks_test/callbacks_test.ino
@@ -1,7 +1,7 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) Arduino s.r.l. and/or its affiliated companies
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/extras/test/callbacks_test/python/main.py
+++ b/extras/test/callbacks_test/python/main.py
@@ -1,3 +1,6 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
 import time
 from arduino.app_utils import *
 

--- a/extras/test/clientSSL/clientSSL.ino
+++ b/extras/test/clientSSL/clientSSL.ino
@@ -1,3 +1,14 @@
+/*
+    This file is part of the Arduino_RouterBridge library.
+
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
 #include <Arduino_RouterBridge.h>
 
 static const char ca_cert[] = {

--- a/extras/test/test_rpc_thread/python/main.py
+++ b/extras/test/test_rpc_thread/python/main.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (C) 2025 ARDUINO SA <http://www.arduino.cc>
-#
-# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
 
 import time
 from arduino.app_utils import *

--- a/extras/test/test_rpc_thread/test_rpc_thread.ino
+++ b/extras/test/test_rpc_thread/test_rpc_thread.ino
@@ -1,3 +1,14 @@
+/*
+    This file is part of the Arduino_RouterBridge library.
+
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
 #include <Arduino_RouterBridge.h>
 #include <zephyr/kernel.h>
 

--- a/extras/test/test_serial_alias_monitor/test_serial_alias_monitor.ino
+++ b/extras/test/test_serial_alias_monitor/test_serial_alias_monitor.ino
@@ -1,7 +1,7 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) Arduino s.r.l. and/or its affiliated companies
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/extras/test/udp_echo/python/main.py
+++ b/extras/test/udp_echo/python/main.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Simple UDP Echo Server
 

--- a/extras/test/udp_echo/udp_echo.ino
+++ b/extras/test/udp_echo/udp_echo.ino
@@ -1,4 +1,15 @@
 /*
+    This file is part of the Arduino_RouterBridge library.
+
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
+/*
  * UDP Echo Test
  * 
  * This sketch tests the BridgeUDP class by sending packets to an echo server

--- a/extras/test/udp_test/python/main.py
+++ b/extras/test/udp_test/python/main.py
@@ -1,3 +1,6 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
 """
 BridgeUDP Python Server Implementation
 

--- a/extras/test/udp_test/udp_test.ino
+++ b/extras/test/udp_test/udp_test.ino
@@ -1,4 +1,15 @@
 /*
+    This file is part of the Arduino_RouterBridge library.
+
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+*/
+
+/*
  * BridgeUDP Test Suite
  *
  * This test suite validates the BridgeUDP class functionality

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -1,7 +1,7 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) 2025 Arduino SA
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/hci.h
+++ b/src/hci.h
@@ -1,7 +1,7 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) 2025 Arduino SA
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -1,7 +1,7 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) 2025 Arduino SA
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/routerbridge_provides_serial.h
+++ b/src/routerbridge_provides_serial.h
@@ -1,7 +1,7 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) Arduino s.r.l. and/or its affiliated companies
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/singletons.cpp
+++ b/src/singletons.cpp
@@ -1,7 +1,7 @@
 /*
     This file is part of the Arduino_RouterBridge library.
 
-    Copyright (c) Arduino s.r.l. and/or its affiliated companies
+    Copyright (C) Arduino s.r.l. and/or its affiliated companies
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
I wanted to keep this PR separated as it concerns the new SPDX policy.

I updated the SPDX only for those files that changed since 0.4.0 (March 16 2026).
Should I consider files that changed since 0.3.0 (December 15 2025) as well?